### PR TITLE
Add Gemm

### DIFF
--- a/src/ONNX.jl
+++ b/src/ONNX.jl
@@ -3,6 +3,7 @@ module ONNX
   include("onnx_pb.jl")
   include("read.jl")
   include("write.jl")
+  include("utils.jl")
   include("conversions.jl")
   include("show.jl")
   include("ops.jl")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,11 +3,4 @@
 
 Create a copy of `d`, replacing its keys according to mapping `subs`
 """
-function rename_keys(dct::Dict, subs::Dict)
-    new = empty(dct)
-    for (key, val) in dct
-        new_key = get(subs, key, key)
-        new[new_key] = val
-    end
-    return new
-end
+rename_keys(dct::Dict, subs::Dict) = Dict(get(subs, k, k) => v for (k, v) in pairs(dct))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,13 @@
+"""
+    rename_keys(d::Dict, subs::Dict)
+
+Create a copy of `d`, replacing its keys according to mapping `subs`
+"""
+function rename_keys(dct::Dict, subs::Dict)
+    new = empty(dct)
+    for (key, val) in dct
+        new_key = get(subs, key, key)
+        new[new_key] = val
+    end
+    return new
+end

--- a/test/ort.jl
+++ b/test/ort.jl
@@ -20,6 +20,8 @@ function ort_test(tape::Tape, args...)
         r3 = tape2[tape2.result].val
         @test isapprox(r1, r2)
         @test isapprox(r1, r3)
+        # for more flexibility we return the tape before saving and after loading
+        return tape, tape2
     end
 end
 
@@ -29,5 +31,5 @@ function ort_test(fn::Function, args...; kwargs...)
     inp = [push!(tape, Input(arg)) for arg in args]
     res = push_call!(tape, fn, inp...; kwargs...)
     tape.result = res
-    ort_test(tape, args...)
+    return ort_test(tape, args...)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,9 @@
 using ONNX
 using Test
+import Ghost: V
 
 include("readwrite.jl")
+include("utils.jl")
 include("conversions.jl")
 include("ort.jl")
 include("saveload.jl")

--- a/test/saveload.jl
+++ b/test/saveload.jl
@@ -5,6 +5,22 @@
         ort_test(ONNX.mul, args...)
     end
 
+    @testset "Gemm" begin
+        A, B, C = (rand(3, 4), rand(3, 4), rand(3, 3))
+        ort_test(ONNX.onnx_gemm, A, B')
+        ort_test(ONNX.onnx_gemm, A', B)
+        ort_test(ONNX.onnx_gemm, A', B, C)
+        ort_test(ONNX.onnx_gemm, A, B, C; tA=1)
+        ort_test(ONNX.onnx_gemm, A, B; tB=1)
+        ort_test(ONNX.onnx_gemm, A', B; α=2.0)
+        ort_test(ONNX.onnx_gemm, A', B, C; α=2.0, β=0.5)
+        # make sure Gemm with just 2 matrices and no keyword arguments
+        # is recorded as just *
+        before, after = ort_test(*, A', B)
+        @test before[V(3)].fn == after[V(3)].fn
+        @test before[V(3)].fn == *
+    end
+
     @testset "Conv" begin
         # 2D, keywords
         args = (rand(Float32, 32, 32, 3, 1), rand(Float32, 3, 3, 3, 6))

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,9 @@
+import ONNX: rename_keys
+
+
+@testset "Utils" begin
+    attrs = Dict(:a => 0, :b => 1)
+    @test rename_keys(attrs, Dict(:a => :c)) == Dict(:c => 0, :b => 1)
+    @test rename_keys(attrs, Dict(:f => :g)) == attrs
+    @test rename_keys(attrs, Dict()) == attrs
+end


### PR DESCRIPTION
`Gemm` is a bit tricky. First, order of arguments is reversed due to row-major indexing. Second, usually in Julia we don't directly write `gemm(A, B, C; tA=1, β=0.5)` or something, but instead use `A * B' + β * C`. We implement such optimizing transformation later, here I only account for two simple cases - simple `*` and complete GEMM.

`onnx_gemm` was implemented in one of the previous PRs and is available [here](https://github.com/FluxML/ONNX.jl/blob/master/src/ops.jl#L19-L31).