### PR TITLE
BatchNormalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 test/models
 test/onnx/
 Manifest.toml
+.vscode/

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,6 @@ uuid = "d0dd6a25-fac6-55c0-abf7-829e0c774d20"
 version = "0.3.0"
 
 [deps]
-Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 Ghost = "4f8f7498-1303-42e1-920c-5033445536df"
 NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -14,3 +13,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 ProtoBuf = "= 0.11.1"
 julia = "1.6"
+Ghost = "0.3.2"
+NNlib = "0.7"

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -96,7 +96,7 @@ function from_nnlib_conv(attrs::Dict, d::Int)
 end
 
 
-function from_onnx_conv(attrs::Dict)
+function from_onnx_conv(attrs::Dict; pooling=false)
     out = Dict{Symbol, Any}()
     haskey(attrs, :auto_pad) && error("auto_pad attribute is currently not supported")
     if haskey(attrs, :strides)
@@ -105,7 +105,8 @@ function from_onnx_conv(attrs::Dict)
     if haskey(attrs, :dilations)
         out[:dilation] = from_onnx_spatial(attrs[:dilations])
     end
-    if haskey(attrs, :kernel_shape)
+    # this attribute is only used for pooling, but not conv
+    if haskey(attrs, :kernel_shape) && pooling
         out[:kernel] = from_onnx_spatial(attrs[:kernel_shape])
     end
     if haskey(attrs, :group)

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -117,3 +117,47 @@ function from_onnx_conv(attrs::Dict; pooling=false)
     end
     return out
 end
+
+
+function from_nnlib_norm(attrs::Dict{K,V}) where {K,V}
+    out = Dict{Symbol, Any}()
+    if haskey(attrs, :training)
+        out[:training_mode] = Int(attrs[:training])
+    end
+    if haskey(attrs, :mtm)
+        # ONNX calculates new running mean as `mtm * input_mean + (1 - mtm) * current_mean`
+        # NNlib/Flux does the opposite, i.e.  `(1 - mtm) * input_mean + mtm * current_mean`
+        # thus we reverse the value here
+        out[:momentum] = 1f0 - attrs[:mtm]
+    end
+    if haskey(attrs, :ϵ)
+        out[:epsilon] = attrs[:ϵ]
+    end
+    return out
+end
+
+
+function from_onnx_norm(attrs::Dict{K,V}) where {K,V}
+    out = Dict{Symbol, Any}()
+    if haskey(attrs, :is_test)
+        out[:training] = Bool(1 - attrs[:is_test])
+    end
+    if haskey(attrs, :training_mode)
+        out[:training] = Bool(attrs[:training_mode])
+    end
+    if haskey(attrs, :spatial) && attrs[:spatial] != 1
+        # deprecated attribute, e.g. see
+        # https://github.com/onnx/onnx/blob/master/docs/Changelog.md#BatchNormalization-14
+        error("BatchNormalization with spatial != 1 is not supported")
+    end
+    if haskey(attrs, :momentum)
+        # ONNX calculates new running mean as `mtm * input_mean + (1 - mtm) * current_mean`
+        # NNlib/Flux does the opposite, i.e.  `(1 - mtm) * input_mean + mtm * current_mean`
+        # thus we reverse the value here
+        out[:mtm] = 1f0 - attrs[:momentum]
+    end
+    if haskey(attrs, :epsilon)
+        out[:ϵ] = attrs[:epsilon]
+    end
+    return out
+end

--- a/src/load.jl
+++ b/src/load.jl
@@ -90,7 +90,7 @@ end
 
 
 function load_node!(tape::Tape, ::OpConfig{:ONNX, :MaxPool}, args::VarVec, attrs::AttrDict)
-    kw = from_onnx_conv(attrs) |> NamedTuple
+    kw = from_onnx_conv(attrs; pooling=true) |> NamedTuple
     return push_call!(tape, maxpool, args[1]; kw...)
 end
 
@@ -133,13 +133,38 @@ end
 
 
 function load_node!(tape::Tape, ::OpConfig{:ONNX, :BatchNormalization},
-    args::VarVec, attrs::AttrDict)
+        args::VarVec, attrs::AttrDict)
+    attrs = copy(attrs)
+    if haskey(attrs, :is_test)
+        attrs[:training_mode] = 1 - attrs[:is_test]
+        delete!(attrs, :is_test)
+    end
+    if haskey(attrs, :spatial)
+        # Reading the doc below, I assume `spatial` attribute has been removed in opset > 14
+        # and later versions always use `spatial=1`
+        # https://github.com/onnx/onnx/blob/master/docs/Changelog.md#BatchNormalization-14
+        @assert attrs[:spatial] == 1 "BatchNormalization with spatial != 1 is not supported"
+        delete!(attrs, :spatial)
+    end
     kw = rename_keys(attrs, Dict(
         :epsilon => :ϵ,
         :momentum => :mtm,
         :training_mode => :training
-    ))
-    return push_call!(tape, batch_norm, args...; kw...)
+    )) |> Dict{Symbol, Any}
+    if haskey(kw, :training)
+        kw[:training] = Bool(kw[:training])
+    end
+    bn = push_call!(tape, batch_norm, args...; kw...)
+    if bn._op.val isa Tuple
+        # usual in training model
+        # unpack tuples into calls to getfield
+        y = push_call!(tape, getfield, bn, 1)
+        μnext = push_call!(tape, getfield, bn, 2)
+        σ²next = push_call!(tape, getfield, bn, 3)
+        return y, μnext, σ²next
+    else
+        return bn
+    end
 end
 
 
@@ -202,7 +227,16 @@ function load(io::IO, model_args...; backends=[:ONNX], exec::Bool=true)
         success || error("Couldn't load node for $(nd.op_type), " *
                          "tried the following backends: $(tape.c.backends)")
     end
-    tape.result = Ghost.bound(tape, V(length(tape)))
+    if length(g.output) == 1
+        tape.result = Ghost.bound(tape, V(length(tape)))
+    else
+        # tuple output: we expect tape to contain these outputs as vars  destructured
+        # from a multi-ouput op using a sequence of `getfield()` calls
+        vars = [tape.c.name2var[name] for name in nd.output]
+        @assert(all(tape[v] isa Call && tape[v].fn == getfield for v in vars),
+            "Don't understand this multi-output result of the graph")
+        tape.result = tape[vars[1]].args[1]
+    end
     return tape
 end
 

--- a/src/load.jl
+++ b/src/load.jl
@@ -132,6 +132,18 @@ end
 # end
 
 
+function load_node!(tape::Tape, ::OpConfig{:ONNX, :BatchNormalization},
+    args::VarVec, attrs::AttrDict)
+    kw = rename_keys(attrs, Dict(
+        :epsilon => :ϵ,
+        :momentum => :mtm,
+        :training_mode => :training
+    ))
+    return push_call!(tape, batch_norm, args...; kw...)
+end
+
+
+
 # function load_node!(tape::Tape, ::OpConfig{:ONNX, :GlobalAveragePool}, args::VarVec, attrs::AttrDict)
 #     return push_call!(tape, global_average_pool, args...)
 # end

--- a/src/ops.jl
+++ b/src/ops.jl
@@ -1,7 +1,6 @@
 # Default implementations of ONNX operators
 
 import NNlib
-import Flux
 import Statistics: mean
 
 
@@ -54,7 +53,7 @@ maxpool(x; kernel, pad = 0, stride = 1) = NNlib.maxpool(x, kernel; pad = pad, st
 # common functional implementation for batch and instance normalization based on
 # https://github.com/FluxML/Flux.jl/blob/06970a5fbbb1cb485c5d2cba597a78fb453fc713/src/layers/normalise.jl#L166-L197
 function normalization(x::AbstractArray{T,N}, γ, β, μ, σ², reduce_dims, affine_shape;
-        ϵ=1e-5f0, mtm=0.1f0, training=false) where {T, N}
+        ϵ=1f-5, mtm=0.1f0, training=false) where {T, N}
     # init variables in the function scope instead of the if's scope
     μnext = μ
     σ²next = σ²
@@ -88,7 +87,7 @@ end
 
 
 function batch_norm(x::AbstractArray{T,N}, γ, β, μ, σ²;
-        ϵ=1e-5, mtm=0.9, training=false) where {T,N}
+        ϵ=1f-5, mtm=0.1f0, training=false) where {T,N}
     reduce_dims = [1:N-2; N]
     affine_shape = ntuple(i -> i == N-1 ? size(x, N-1) : 1, N)
     return normalization(x, γ, β, μ, σ², reduce_dims, affine_shape;
@@ -97,7 +96,7 @@ end
 
 
 function instance_norm(x::AbstractArray{T,N}, γ, β, μ, σ²;
-        ϵ=1e-5, mtm=0.9, training=false) where {T,N}
+        ϵ=1f-5, mtm=0.1f0, training=false) where {T,N}
     reduce_dims = 1:N-2
     affine_shape = ntuple(i -> i == N-1 ? size(x, N-1) : 1, N)
     return normalization(x, γ, β, μ, σ², reduce_dims, affine_shape;
@@ -105,6 +104,6 @@ function instance_norm(x::AbstractArray{T,N}, γ, β, μ, σ²;
 end
 
 
-function global_average_pool(x)
-    return Flux.GlobalMeanPool()(x)
-end
+# function global_average_pool(x)
+#     return Flux.GlobalMeanPool()(x)
+# end

--- a/src/ops.jl
+++ b/src/ops.jl
@@ -2,6 +2,7 @@
 
 import NNlib
 import Flux
+import Statistics: mean
 
 
 flipweights(w::AbstractArray{T,N}) where {T,N} = w[(size(w, i):-1:1 for i = 1:(N-2))..., :, :]

--- a/src/ops.jl
+++ b/src/ops.jl
@@ -54,7 +54,7 @@ maxpool(x; kernel, pad = 0, stride = 1) = NNlib.maxpool(x, kernel; pad = pad, st
 # common functional implementation for batch and instance normalization based on
 # https://github.com/FluxML/Flux.jl/blob/06970a5fbbb1cb485c5d2cba597a78fb453fc713/src/layers/normalise.jl#L166-L197
 function normalization(x::AbstractArray{T,N}, γ, β, μ, σ², reduce_dims, affine_shape;
-        ϵ=1e-5, mtm=0.9, training=false) where {T, N}
+        ϵ=1e-5f0, mtm=0.1f0, training=false) where {T, N}
     # init variables in the function scope instead of the if's scope
     μnext = μ
     σ²next = σ²
@@ -63,7 +63,7 @@ function normalization(x::AbstractArray{T,N}, γ, β, μ, σ², reduce_dims, aff
         μ = reshape(μ, stats_shape)
         σ² = reshape(σ², stats_shape)
     else  # trainmode or testmode without tracked stats
-        μold= μ
+        μold = μ
         σ²old = σ²
         μ = mean(x; dims = reduce_dims)
         σ² = mean((x .- μ) .^ 2; dims = reduce_dims)
@@ -103,65 +103,6 @@ function instance_norm(x::AbstractArray{T,N}, γ, β, μ, σ²;
     return normalization(x, γ, β, μ, σ², reduce_dims, affine_shape;
         ϵ=ϵ, mtm=mtm, training=training)
 end
-
-
-
-
-
-# function _norm_layer_forward(l, x::AbstractArray{T,N}; reduce_dims, affine_shape) where {T,N}
-#     if !_isactive(l) && l.track_stats # testmode with tracked stats
-#         stats_shape = ntuple(i -> i == N - 1 ? size(x, N - 1) : 1, N)
-#         μ = reshape(l.μ, stats_shape)
-#         σ² = reshape(l.σ², stats_shape)
-#     else  # trainmode or testmode without tracked stats
-#         μ = mean(x; dims = reduce_dims)
-#         σ² = mean((x .- μ) .^ 2; dims = reduce_dims)
-#         if l.track_stats
-#             ## update moving mean/std
-#             Zygote.ignore() do
-#                 mtm = l.momentum
-#                 m = prod(size(x, i) for i in reduce_dims)  # needed for computing corrected var
-#                 μnew = vec(N ∈ reduce_dims ? μ : mean(μ, dims = N))
-#                 σ²new = vec(N ∈ reduce_dims ? σ² : mean(σ², dims = N))
-#                 l.μ = (1 - mtm) .* l.μ .+ mtm .* μnew
-#                 l.σ² = (1 - mtm) .* l.σ² .+ mtm .* (m / (m - one(eltype(l.σ²)))) .* σ²new
-#             end
-#         end
-#     end
-#     if hasaffine(l)
-#         γ = reshape(l.γ, affine_shape)
-#         β = reshape(l.β, affine_shape)
-#         return l.λ.(γ .* (x .- μ) ./ sqrt.(σ² .+ l.ϵ) .+ β)
-#     else
-#         return l.λ.((x .- μ) ./ sqrt.(σ² .+ l.ϵ))
-#     end
-# end
-
-
-# mutable struct BatchNorm{F,V,N,W}
-#     λ::F  # activation function
-#     β::V  # bias
-#     γ::V  # scale
-#     μ::W     # moving mean
-#     σ²::W    # moving var
-#     ϵ::N
-#     momentum::N
-#     affine::Bool
-#     track_stats::Bool
-#     active::Union{Bool, Nothing}
-#     chs::Int # number of channels
-#   end
-
-# function batch_norm(x, γ, β, μ, σ², ϵ, momentum, training_mode)
-#     bn = Flux.BatchNorm(
-#         identity, β, γ, μ, σ², ϵ, momentum, true, true, nothing, length(γ))
-#     y = bn(x)
-#     if training_mode
-#         return y, bn.μ, bn.σ²  # TODO: are bn.μ and bn.σ² actually updated?
-#     else
-#         return y
-#     end
-# end
 
 
 function global_average_pool(x)

--- a/src/ops.jl
+++ b/src/ops.jl
@@ -4,7 +4,7 @@ import NNlib
 import Flux
 
 
-flipweights(w::AbstractArray{T, N}) where {T,N} = w[(size(w,i):-1:1 for i in 1:(N-2))..., :, :]
+flipweights(w::AbstractArray{T,N}) where {T,N} = w[(size(w, i):-1:1 for i = 1:(N-2))..., :, :]
 
 conv(x, w; kw...) = NNlib.conv(x, flipweights(w); kw...)
 
@@ -16,14 +16,14 @@ function conv(x, w, b; kw...)
 end
 
 
-function onnx_gemm(A, B, C; tA=0, tB=false, α=1, β=1)
+function onnx_gemm(A, B, C; tA = 0, tB = false, α = 1, β = 1)
     A = Bool(tA) ? A' : A
     B = Bool(tB) ? B' : B
     # note: order of arguments reversed due to row-major layout
     return α * B * A .+ β * C
 end
 
-function onnx_gemm(A, B; tA=0, tB=0, α=1)
+function onnx_gemm(A, B; tA = 0, tB = 0, α = 1)
     A = Bool(tA) ? A' : A
     B = Bool(tB) ? B' : B
     # note: order of arguments reversed due to row-major layout
@@ -31,23 +31,110 @@ function onnx_gemm(A, B; tA=0, tB=0, α=1)
 end
 
 # Julia-friendly flatten
-function flatten(x; dim=ndims(x) - 1)
+function flatten(x; dim = ndims(x) - 1)
     sz = size(x)
-    keep = dim < ndims(x) ? sz[dim + 1:end] : 1
+    keep = dim < ndims(x) ? sz[dim+1:end] : 1
     return reshape(x, :, keep...)
 end
 
 # ONNX-specific flatten
-function onnx_flatten(x; axis=1)
+function onnx_flatten(x; axis = 1)
     dim = axis >= 0 ? ndims(x) - axis + 1 : axis + 1
-    return flatten(x; dim=dim)
+    return flatten(x; dim = dim)
 
 end
 
 add(xs...) = +(xs...)
 mul(xs...) = .*(xs...)
 relu(x) = NNlib.relu.(x)
-maxpool(x; kernel, pad=0, stride=1) = NNlib.maxpool(x, kernel; pad=pad, stride=stride)
+maxpool(x; kernel, pad = 0, stride = 1) = NNlib.maxpool(x, kernel; pad = pad, stride = stride)
+
+
+# common functional implementation for batch and instance normalization based on
+# https://github.com/FluxML/Flux.jl/blob/06970a5fbbb1cb485c5d2cba597a78fb453fc713/src/layers/normalise.jl#L166-L197
+function normalization(x::AbstractArray{T,N}, γ, β, μ, σ², reduce_dims, affine_shape;
+        ϵ=1e-5, mtm=0.9, training=false) where {T, N}
+    # init variables in the function scope instead of the if's scope
+    μnext = μ
+    σ²next = σ²
+    if !training  # testmode
+        stats_shape = ntuple(i -> i == N - 1 ? size(x, N - 1) : 1, N)
+        μ = reshape(μ, stats_shape)
+        σ² = reshape(σ², stats_shape)
+    else  # trainmode or testmode without tracked stats
+        μold= μ
+        σ²old = σ²
+        μ = mean(x; dims = reduce_dims)
+        σ² = mean((x .- μ) .^ 2; dims = reduce_dims)
+        m = prod(size(x, i) for i in reduce_dims)  # needed for computing corrected var
+        μnew = vec(N ∈ reduce_dims ? μ : mean(μ, dims = N))
+        σ²new = vec(N ∈ reduce_dims ? σ² : mean(σ², dims = N))
+        μnext = (1 - mtm) .* μold .+ mtm .* μnew
+        σ²next = (1 - mtm) .* σ²old .+ mtm .* (m / (m - one(eltype(σ²old)))) .* σ²new
+    end
+    out = (x .- μ) ./ sqrt.(σ² .+ ϵ)
+    if !isnothing(γ) && !isnothing(β)
+        γ = reshape(γ, affine_shape)
+        β = reshape(β, affine_shape)
+        out = γ .* out .+ β
+    end
+    if training
+        return out, μnext, σ²next
+    else
+        return out
+    end
+end
+
+
+function batch_norm(x::AbstractArray{T,N}, γ, β, μ, σ²;
+        ϵ=1e-5, mtm=0.9, training=false) where {T,N}
+    reduce_dims = [1:N-2; N]
+    affine_shape = ntuple(i -> i == N-1 ? size(x, N-1) : 1, N)
+    return normalization(x, γ, β, μ, σ², reduce_dims, affine_shape;
+        ϵ=ϵ, mtm=mtm, training=training)
+end
+
+
+function instance_norm(x::AbstractArray{T,N}, γ, β, μ, σ²;
+        ϵ=1e-5, mtm=0.9, training=false) where {T,N}
+    reduce_dims = 1:N-2
+    affine_shape = ntuple(i -> i == N-1 ? size(x, N-1) : 1, N)
+    return normalization(x, γ, β, μ, σ², reduce_dims, affine_shape;
+        ϵ=ϵ, mtm=mtm, training=training)
+end
+
+
+
+
+
+# function _norm_layer_forward(l, x::AbstractArray{T,N}; reduce_dims, affine_shape) where {T,N}
+#     if !_isactive(l) && l.track_stats # testmode with tracked stats
+#         stats_shape = ntuple(i -> i == N - 1 ? size(x, N - 1) : 1, N)
+#         μ = reshape(l.μ, stats_shape)
+#         σ² = reshape(l.σ², stats_shape)
+#     else  # trainmode or testmode without tracked stats
+#         μ = mean(x; dims = reduce_dims)
+#         σ² = mean((x .- μ) .^ 2; dims = reduce_dims)
+#         if l.track_stats
+#             ## update moving mean/std
+#             Zygote.ignore() do
+#                 mtm = l.momentum
+#                 m = prod(size(x, i) for i in reduce_dims)  # needed for computing corrected var
+#                 μnew = vec(N ∈ reduce_dims ? μ : mean(μ, dims = N))
+#                 σ²new = vec(N ∈ reduce_dims ? σ² : mean(σ², dims = N))
+#                 l.μ = (1 - mtm) .* l.μ .+ mtm .* μnew
+#                 l.σ² = (1 - mtm) .* l.σ² .+ mtm .* (m / (m - one(eltype(l.σ²)))) .* σ²new
+#             end
+#         end
+#     end
+#     if hasaffine(l)
+#         γ = reshape(l.γ, affine_shape)
+#         β = reshape(l.β, affine_shape)
+#         return l.λ.(γ .* (x .- μ) ./ sqrt.(σ² .+ l.ϵ) .+ β)
+#     else
+#         return l.λ.((x .- μ) ./ sqrt.(σ² .+ l.ϵ))
+#     end
+# end
 
 
 # mutable struct BatchNorm{F,V,N,W}
@@ -64,16 +151,16 @@ maxpool(x; kernel, pad=0, stride=1) = NNlib.maxpool(x, kernel; pad=pad, stride=s
 #     chs::Int # number of channels
 #   end
 
-function batch_norm(x, γ, β, μ, σ², ϵ, momentum, training_mode)
-    bn = Flux.BatchNorm(
-        identity, β, γ, μ, σ², ϵ, momentum, true, true, nothing, length(γ))
-    y = bn(x)
-    if training_mode
-        return y, bn.μ, bn.σ²  # TODO: are bn.μ and bn.σ² actually updated?
-    else
-        return y
-    end
-end
+# function batch_norm(x, γ, β, μ, σ², ϵ, momentum, training_mode)
+#     bn = Flux.BatchNorm(
+#         identity, β, γ, μ, σ², ϵ, momentum, true, true, nothing, length(γ))
+#     y = bn(x)
+#     if training_mode
+#         return y, bn.μ, bn.σ²  # TODO: are bn.μ and bn.σ² actually updated?
+#     else
+#         return y
+#     end
+# end
 
 
 function global_average_pool(x)

--- a/src/save.jl
+++ b/src/save.jl
@@ -161,7 +161,7 @@ function save_node!(g::GraphProto, ::@opconfig_kw(:ONNX, batch_norm), op::Ghost.
     attrs = from_nnlib_norm(kw_dict)
     args = iskwfunc(op.fn) ? op.args[3:end] : op.args
     output = if Bool(get(attrs, :training_mode, 0))
-        vars = unpacked_vars(tape, op)
+        vars = unpacked_vars(op)
         @assert(all([v isa V for v in vars]),
             "Not all output vars of batch_norm are unpacked to the tape")
         [onnx_name(v) for v in vars]
@@ -215,7 +215,7 @@ function save(io::IO, tape::Tape{ONNXCtx})
     if res.val isa Tuple
         # if the last operation in the graph is multi-output, there must be
         # unpacked elements of that var
-        vars = unpacked_vars(tape, res)
+        vars = unpacked_vars(res)
         @assert(all(v isa V for v in vars), "Cannot save the tape because the result " *
             "is multi-output, but its elements aren't destructured to the tape")
         for v in vars

--- a/src/save.jl
+++ b/src/save.jl
@@ -158,15 +158,7 @@ end
 
 function save_node!(g::GraphProto, ::@opconfig_kw(:ONNX, batch_norm), op::Ghost.Call)
     kw_dict = kwargs2dict(op)
-    attrs = rename_keys(kw_dict, Dict(
-        :ϵ => :epsilon,
-        :mtm => :momentum,
-        :training => :training_mode
-    )) |> Dict{Symbol, Any}
-    if haskey(attrs, :training_mode)
-        # true -> 1, false -> 0
-        attrs[:training_mode] = Int(attrs[:training_mode])
-    end
+    attrs = from_nnlib_norm(kw_dict)
     args = iskwfunc(op.fn) ? op.args[3:end] : op.args
     output = if Bool(get(attrs, :training_mode, 0))
         vars = unpacked_vars(tape, op)

--- a/src/save.jl
+++ b/src/save.jl
@@ -58,7 +58,7 @@ end
 
 ValueInfoProto(op::Ghost.AbstractOp) = ValueInfoProto(
     onnx_name(op),
-    # something down the road reverses the shape, so we don't do it here
+    # utils in write.jl reverse the shape, so we don't do it here
     # try the following for example:
     #     TypeProto_Tensor((4, 3), Float64).shape.dim[1].dim_value
     # which gives 3 instead of 4
@@ -145,6 +145,18 @@ end
 
 function save_node!(g::GraphProto, ::OpConfig{:ONNX, typeof(relu)}, op::Ghost.Call)
     nd = NodeProto("Relu", op)
+    push!(g.node, nd)
+end
+
+
+function save_node!(g::GraphProto, ::@opconfig_kw(:ONNX, batch_norm), op::Ghost.Call)
+    kw_dict = kwargs2dict(op)
+    attrs = rename_keys(kw_dict, Dict(
+        :ϵ => :epsilon,
+        :mtm => :momentum,
+        :training => :training_mode
+    ))
+    nd = NodeProto("BatchNormalization", op, attrs)
     push!(g.node, nd)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,51 @@
-"""
-    rename_keys(d::Dict, subs::Dict)
+import Ghost: Tape, Input, Call, mkcall, V
 
-Create a copy of `d`, replacing its keys according to mapping `subs`
+
+"""
+    rename_keys(dict::Dict, subs::Dict)
+
+Create a copy of `dict`, replacing its keys according to mapping `subs`
 """
 rename_keys(dct::Dict, subs::Dict) = Dict(get(subs, k, k) => v for (k, v) in pairs(dct))
+
+
+"""
+    unpacked_vars(tape::Ghost.Tape, op::Ghost.Call)
+
+For a multi-output call, find variables on the tape referring to elements of the output.
+Example:
+
+    import Ghost: Tape, Input, mkcall
+
+    make_tuple(x) = (x, x + 1)
+
+    tape = Tape()
+    x = push!(tape, Input(1.0))
+    out = push!(tape, mkcall(make_tuple, x))
+    y1 = push!(tape, mkcall(getfield, out, 1))
+    y2 = push!(tape, mkcall(getfield, out, 2))
+
+    @assert unpacked_vars(tape, tape[out]) == [y1, y2]
+
+"""
+function unpacked_vars(tape::Tape, op::Call)
+    @assert op.val isa Tuple "Can't unpack non-tuple output"
+    # out = V(op)
+    vars = Any[nothing for _=1:length(op.val)]
+    found = 0
+    for id in op.id + 1:length(tape)
+        cur = tape[V(id)]
+        if (cur isa Call && cur.fn in (getfield, getindex) &&   # is getfield call
+            cur.args[1] isa V && cur.args[1].id == op.id)       # with V(op) as the first argument
+            # found unpacked var
+            idx = cur.args[2]
+            idx = idx isa V ? tape[idx].val : idx
+            vars[idx] = V(cur)
+            # in most cases unpacked vars go right after the multi-ouput,
+            # no need to search further
+            found += 1
+            found == length(vars) && break
+        end
+    end
+    return vars
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -28,8 +28,9 @@ Example:
     @assert unpacked_vars(tape, tape[out]) == [y1, y2]
 
 """
-function unpacked_vars(tape::Tape, op::Call)
+function unpacked_vars(op::Call)
     @assert op.val isa Tuple "Can't unpack non-tuple output"
+    tape = op.tape
     # out = V(op)
     vars = Any[nothing for _=1:length(op.val)]
     found = 0

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -4,4 +4,4 @@ ONNXRunTime = "e034b28e-924e-41b2-b98f-d2bbeb830c6a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Ghost = "0.2.1"
+Ghost = "0.3"

--- a/test/ort.jl
+++ b/test/ort.jl
@@ -21,8 +21,8 @@ function ort_test(tape::Tape, args...)
             from_onnx(first(values(r2_onnx)))
         tape2 = load(path, args...; exec=true)
         r3 = tape2[tape2.result].val
-        @test r1 isa Tuple ? isapprox.(r1, r2) : isapprox(r1, r2)
-        @test r1 isa Tuple ? isapprox.(r1, r3) : isapprox(r1, r3)
+        @test r1 isa Tuple ? all(isapprox.(r1, r2)) : isapprox(r1, r2)
+        @test r1 isa Tuple ? all(isapprox.(r1, r3)) : isapprox(r1, r3)
         # for more flexibility we return the tape before saving and after loading
         return tape, tape2
     end

--- a/test/ort.jl
+++ b/test/ort.jl
@@ -11,7 +11,7 @@ function ort_run(path, ort_args...)
 end
 
 
-function ort_test(tape::Tape, args...)
+function ort_test(tape::Tape, args...; atol=0)
     mktemp() do path, _
         r1 = play!(tape, args...)
         save(path, tape)
@@ -21,8 +21,8 @@ function ort_test(tape::Tape, args...)
             from_onnx(first(values(r2_onnx)))
         tape2 = load(path, args...; exec=true)
         r3 = tape2[tape2.result].val
-        @test r1 isa Tuple ? all(isapprox.(r1, r2)) : isapprox(r1, r2)
-        @test r1 isa Tuple ? all(isapprox.(r1, r3)) : isapprox(r1, r3)
+        @test r1 isa Tuple ? all(isapprox.(r1, r2; atol=atol)) : isapprox(r1, r2; atol=atol)
+        @test r1 isa Tuple ? all(isapprox.(r1, r3; atol=atol)) : isapprox(r1, r3; atol=atol)
         # for more flexibility we return the tape before saving and after loading
         return tape, tape2
     end

--- a/test/saveload.jl
+++ b/test/saveload.jl
@@ -63,4 +63,9 @@
         ort_test(ONNX.relu, x)
     end
 
+    @testset "Normalization" begin
+        x = rand(7, 7, 3, 5); γ = rand(3); β = rand(3); μ = rand(3); σ² = rand(3)
+        ort_test(ONNX.batch_norm, x, γ, β, μ, σ²)
+    end
+
 end

--- a/test/saveload.jl
+++ b/test/saveload.jl
@@ -79,8 +79,7 @@
         s2 = push_call!(tape, getfield, bn, 3)
         tape.result = bn
 
-        # at the moment next mean and variance differ in ONNX and our implementation
-        @test_broken ort_test(tape, args...)
+        ort_test(tape, args...; atol=1e-4)
     end
 
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,9 +1,27 @@
-import ONNX: rename_keys
+import ONNX: rename_keys, unpacked_vars
+import Ghost: Tape, Input, mkcall
 
 
 @testset "Utils" begin
+    # rename_keys
     attrs = Dict(:a => 0, :b => 1)
     @test rename_keys(attrs, Dict(:a => :c)) == Dict(:c => 0, :b => 1)
     @test rename_keys(attrs, Dict(:f => :g)) == attrs
     @test rename_keys(attrs, Dict()) == attrs
+
+    # unpacked_vars
+    make_tuple(x) = (x, x + 1)
+
+    tape = Tape()
+    x = push!(tape, Input(1.0))
+    out = push!(tape, mkcall(make_tuple, x))
+    y1 = push!(tape, mkcall(getfield, out, 1))
+    y2 = push!(tape, mkcall(getfield, out, 2))
+    @test unpacked_vars(tape, tape[out]) == [y1, y2]
+
+    tape = Tape()
+    x = push!(tape, Input(1.0))
+    out = push!(tape, mkcall(make_tuple, x))
+    y1 = push!(tape, mkcall(getfield, out, 1))
+    @test unpacked_vars(tape, tape[out]) == [y1, nothing]
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -17,11 +17,11 @@ import Ghost: Tape, Input, mkcall
     out = push!(tape, mkcall(make_tuple, x))
     y1 = push!(tape, mkcall(getfield, out, 1))
     y2 = push!(tape, mkcall(getfield, out, 2))
-    @test unpacked_vars(tape, tape[out]) == [y1, y2]
+    @test unpacked_vars(tape[out]) == [y1, y2]
 
     tape = Tape()
     x = push!(tape, Input(1.0))
     out = push!(tape, mkcall(make_tuple, x))
     y1 = push!(tape, mkcall(getfield, out, 1))
-    @test unpacked_vars(tape, tape[out]) == [y1, nothing]
+    @test unpacked_vars(tape[out]) == [y1, nothing]
 end


### PR DESCRIPTION
There are 2 main changes: 

1. Support for multi-output nodes in the graph.
2. BatchNormalization in test mode. 

BatchNormalization in train mode is also implemented, but the result diverges from the one produced with ONNXRunTime. One difference that I fixed is the handling of momentum and corresponding default value: in Flux, which I mostly borrowed the code for norm layers, we use: 
```
running_mean * (1 - momentum) + current_mean * momentum
```
while in ONNX it's the opposite: 
```
running_mean * momentum + current_mean * (1 - mementum)
```
Thus default value is `mtm=0.1` in Flux and `momentum=0.9` in ONNX. But even after fixing it I still can't get equivalent results and can't immediately spot the difference from the implementation described in [the docs](https://github.com/onnx/onnx/blob/master/docs/Operators.md#BatchNormalization).

Anyway, using ONNX in training mode looks more like an advanced features, so for now I just marked the test as broken. In there are no concerns about it from anyone in the next 24 hours, I'm going to merge it and put to the end of backlog. 