### PR TITLE
Add Unsquezee operation

### DIFF
--- a/src/load.jl
+++ b/src/load.jl
@@ -162,6 +162,20 @@ function load_node!(tape::Tape, ::OpConfig{:ONNX, :Gather}, args::VarVec, attrs:
 end
 
 
+function load_node!(tape::Tape, ::OpConfig{:ONNX, :Unsqueeze}, args::VarVec, attrs::AttrDict)
+    if length(args) == 2
+        # ONNX >= v13
+        return push_call!(tape, onnx_unsqueeze, args...)
+    elseif length(args) == 1
+        # ONNX < v13
+        axes = attrs[:axes]
+        v_axes = push!(tape, Constant(axes))
+        return push_call!(tape, onnx_unsqueeze, args[1], v_axes)
+    else
+        throw(ArgumentError("Cannot load node from Unsqueeze with $(length(args)) arguments"))
+    end
+end
+
 ###############################################################################
 #                                    API                                      #
 ###############################################################################

--- a/src/ops.jl
+++ b/src/ops.jl
@@ -178,3 +178,24 @@ function onnx_gather(
     idxs_adjusted = idxs .+ 1
     return take(data, idxs_adjusted; dim=dim)
 end
+
+
+# julia-friendly
+function NNlib.unsqueeze(x::AbstractArray, dims)
+    new_shape = collect(size(x))
+    for d in sort(collect(dims))
+        insert!(new_shape, d, 1)
+    end
+    return reshape(x, new_shape...)
+end
+
+
+# ONNX-friendly, e.g. axes is 0-based, row-major
+function onnx_unsqueeze(x::AbstractArray, axes::Vector)
+    # ndims(data) + length(axes) => size of the array after unsqueezing
+    # .- axes                    => to reverse dimensions
+    # .+ 1                       => to convert to 1-based indexing
+    # .- 1                       => correction by 1
+    dims = ndims(x) + length(axes) .- axes
+    return NNlib.unsqueeze(x, dims)
+end

--- a/src/save.jl
+++ b/src/save.jl
@@ -209,7 +209,7 @@ function save_node!(g::GraphProto, ::OpConfig{:ONNX, <:Any}, op::Ghost.Constant)
         output=[onnx_name(op)],
         name=onnx_name(op),
         attribute=AttributeProto.([attr_name], [attr_value]),
-        op_type=op_type
+        op_type="Constant"
     )
     push!(g.node, nd)
 end
@@ -221,6 +221,12 @@ function save_node!(g::GraphProto, ::@opconfig_kw(:ONNX, onnx_gather), op::Ghost
     dim = get(kw_dict, :dim, ndims(data))
     axis = ndims(data) - dim
     nd = NodeProto("Gather", op, Dict(:axis => axis))
+    push!(g.node, nd)
+end
+
+
+function save_node!(g::GraphProto, ::@opconfig_kw(:ONNX, onnx_unsqueeze), op::Ghost.Call)
+    nd = NodeProto("Unsqueeze", op)
     push!(g.node, nd)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using ONNX
 using Test
 import Ghost: V
+import ONNX.NNlib as NNlib
 
 include("ops.jl")
 include("readwrite.jl")

--- a/test/saveload.jl
+++ b/test/saveload.jl
@@ -115,4 +115,11 @@
         ort_test(ONNX.onnx_gather, data, idxs)
     end
 
+
+    @testset "Unsqueeze" begin
+        ort_test(ONNX.onnx_unsqueeze, rand(2, 3, 4), [0, 4])
+        ort_test(ONNX.onnx_unsqueeze, rand(2, 3, 4), [0, 3])
+        ort_test(ONNX.onnx_unsqueeze, [4.0], [0])
+    end
+
 end


### PR DESCRIPTION
It's funny to see how seemingly simple operation like adding a new singleton dimension to an array turns out to be a beast with a billion corner cases. I'm pretty much sure we will revisit this implementation in the future, fixing bugs and extending its behavior, but the current implementation passes standard tests and is enough to load the op from an actual BERT graph, so let's solve the problems as they come. 