### PR TITLE
Represent array size with SVector

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 ProtoBuf = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/src/load.jl
+++ b/src/load.jl
@@ -52,14 +52,19 @@ function load_node!(tape::Tape, nd::NodeProto, backend::Symbol)
     args = [tape.c.name2var[name] for name in nd.input]
     attrs = convert(Dict{Symbol, Any}, Dict(nd.attribute))
     conf = OpConfig{backend, Symbol(nd.op_type)}()
-    out = load_node!(tape, conf, args, attrs)
-    ismissing(out) && return out
-    if out isa Tuple
-        for i=1:length(nd.output)
-            tape.c.name2var[nd.output[i]] = out[i]
+    try
+        out = load_node!(tape, conf, args, attrs)
+        ismissing(out) && return out
+        if out isa Tuple
+            for i=1:length(nd.output)
+                tape.c.name2var[nd.output[i]] = out[i]
+            end
+        else
+            tape.c.name2var[nd.output[1]] = out
         end
-    else
-        tape.c.name2var[nd.output[1]] = out
+    catch
+        @error "Error while loading node $nd"
+        rethrow()
     end
 end
 


### PR DESCRIPTION
Here's an interesting case. ONNX doesn't support rich data types and thus represents as many things as possible with arrays. In particular:

* `Shape` (== `size_vector`) returns a small array, representing data size
* `Gather` (== `take`), when `idxs` contains only one index, is equivalent to `getindex(..., idxs)`

Using `Gather` as `getindex` works fine for normal arrays, for which dimensions are reversed when parsing protos. However, if we have:

```julia
sz = Shape(data)
dim_len = Gather(sz, idxs)
```
`sz` represents the size of the Julia-friendly array, but `idxs` is still in ONNX-friendly format, i.e. pointing to the _wrong_ dimension!

To avoid this:

1. I make `size_vector` return `SVector` instead of a normal array to distinguish between size vector and actual small array
2. Convert `idxs` in `Gather` into a proper Julia-friendly index.