### PR TITLE
Add MatMul

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.3.0"
 
 [deps]
 Ghost = "4f8f7498-1303-42e1-920c-5033445536df"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 ProtoBuf = "3349acd9-ac6a-5e09-bcdb-63829b23a429"

--- a/src/ops.jl
+++ b/src/ops.jl
@@ -4,6 +4,7 @@ import NNlib
 import Statistics: mean
 import StaticArrays: SVector
 
+using LinearAlgebra
 
 flipweights(w::AbstractArray{T,N}) where {T,N} = w[(size(w, i):-1:1 for i = 1:(N-2))..., :, :]
 

--- a/src/save.jl
+++ b/src/save.jl
@@ -168,6 +168,18 @@ function save_node!(g::GraphProto, ::OpConfig{:ONNX, typeof(relu)}, op::Ghost.Ca
 end
 
 
+function save_node!(g::GraphProto, ::OpConfig{:ONNX, typeof(NNlib.batched_mul)}, op::Ghost.Call)
+    nd = NodeProto(
+        input=[onnx_name(v) for v in reverse(op.args)],
+        output=[onnx_name(op)],
+        name=onnx_name(op),
+        attribute=AttributeProto[],
+        op_type="MatMul"
+    )
+    push!(g.node, nd)
+end
+
+
 function save_node!(g::GraphProto, ::@opconfig_kw(:ONNX, batch_norm), op::Ghost.Call)
     kw_dict = kwargs2dict(op)
     attrs = from_nnlib_norm(kw_dict)

--- a/test/saveload.jl
+++ b/test/saveload.jl
@@ -55,8 +55,8 @@ import ONNX: NodeProto, ValueInfoProto, AttributeProto, onnx_name
             seek(io, 0)
             r2_onnx = ort_run(path, from_nnlib(a.val), from_nnlib(b.val))
             r2 = from_onnx(first(values(r2_onnx)))
-            @test c.val == r2
-            @test c.val == load(path, a.val, b.val)[V(3)].val
+            @test c.val ≈ r2
+            @test c.val ≈ load(path, a.val, b.val)[V(3)].val
         end
     end
 

--- a/test/saveload.jl
+++ b/test/saveload.jl
@@ -21,6 +21,12 @@
         @test before[V(3)].fn == *
     end
 
+    @testset "MatMul" begin
+        ort_test(NNlib.batched_mul, rand(3, 4, 5), rand(4, 3))
+        ort_test(NNlib.batched_mul, rand(3, 4), rand(4, 3, 5))
+        ort_test(NNlib.batched_mul, rand(3, 4, 5), rand(4, 3, 5))
+    end
+
     @testset "Conv" begin
         # 2D, keywords
         args = (rand(Float32, 32, 32, 3, 1), rand(Float32, 3, 3, 3, 6))

--- a/test/saveload.jl
+++ b/test/saveload.jl
@@ -1,3 +1,7 @@
+import ONNX: graphproto, modelproto, writeproto
+import ONNX: NodeProto, ValueInfoProto, AttributeProto, onnx_name
+
+
 @testset "Save and Load" begin
     @testset "Basic ops" begin
         args = (rand(3, 4), rand(3, 4))
@@ -25,6 +29,35 @@
         ort_test(NNlib.batched_mul, rand(3, 4, 5), rand(4, 3))
         ort_test(NNlib.batched_mul, rand(3, 4), rand(4, 3, 5))
         ort_test(NNlib.batched_mul, rand(3, 4, 5), rand(4, 3, 5))
+
+        # 2D*2D case; since it's already covered by Gemm, we have to
+        # manually construct the graph
+        g = graphproto()
+        g.name = "generated_model"
+        a = Input(rand(3, 4)); a.id = 1
+        push!(g.input, ValueInfoProto(a))
+        b = Input(rand(4, 5)); b.id = 2
+        push!(g.input, ValueInfoProto(b))
+        c = mkcall(*, V(a), V(b)); c.id = 3
+        nd = NodeProto(
+            input=[onnx_name(b), onnx_name(a)],
+            output=[onnx_name(c)],
+            name=onnx_name(c),
+            attribute=AttributeProto[],
+            op_type="MatMul"
+        )
+        push!(g.node, nd)
+        push!(g.output, ValueInfoProto(c))
+        m = modelproto();
+        m.graph = g;
+        mktemp() do path, io
+            writeproto(io, m)
+            seek(io, 0)
+            r2_onnx = ort_run(path, from_nnlib(a.val), from_nnlib(b.val))
+            r2 = from_onnx(first(values(r2_onnx)))
+            @test c.val == r2
+            @test c.val == load(path, a.val, b.val)[V(3)].val
+        end
     end
 
     @testset "Conv" begin


### PR DESCRIPTION
Handles 2Dx3D, 3Dx2D and 3Dx3D matrix multiplication. 2Dx2D is loaded as `*`, which is treated as Gemm instead of MatMul, so this transformation is not really reversible. Other cases, e.g. 1D and ND with N > 3 are not supported at the moment.