### PR TITLE
Implement Split, Concat, Elu and Tanh

### DIFF
--- a/src/ops.jl
+++ b/src/ops.jl
@@ -50,7 +50,7 @@ sub(xs...) = .-(xs...)
 mul(xs...) = .*(xs...)
 relu(x) = NNlib.relu.(x)
 elu(x) = NNlib.elu.(x)
-tanh(x) = NNlib.tanh.(x)
+tanh(x) = Base.tanh.(x)
 maxpool(x; kernel, pad = 0, stride = 1) = NNlib.maxpool(x, kernel; pad = pad, stride = stride)
 
 

--- a/test/saveload.jl
+++ b/test/saveload.jl
@@ -109,6 +109,8 @@ import ONNX: NodeProto, ValueInfoProto, AttributeProto, onnx_name
     @testset "Activations" begin
         x = rand(3, 4)
         ort_test(ONNX.relu, x)
+        # ort_test(ONNX.elu, x) # TODO: Elu is not implemented in ONNXRuntime.jl
+        ort_test(ONNX.tanh, x)
     end
 
     @testset "Normalization" begin
@@ -167,4 +169,26 @@ import ONNX: NodeProto, ValueInfoProto, AttributeProto, onnx_name
         ort_test(ONNX.onnx_slice, rand(5, 10, 20), [0, 0, 0], [3, 10, 5])
         ort_test(ONNX.onnx_slice, rand(5, 10, 20), [3, 0], [0, 10], [0, 1], [1, -1])
     end
+
+    @testset "Concat" begin
+        ort_test(ONNX.onnx_concat, [1, 2, 3], [4, 5, 6]; axis=0)
+        ort_test(ONNX.onnx_concat, [1, 2, 3], [4, 5, 6]; axis=-1)
+
+        ort_test(ONNX.onnx_concat, [1 2 3; 1 2 3], [4  5; 4 5]; axis=0)
+    end
+
+    # TODO: Split is not implemented in ONNXRuntime.jl
+    # @testset "Split" begin
+    #     x = rand(3, 20, 10); split = [5, 10, 5];
+    #     args = (x, split)
+    #     tape = Tape(ONNXCtx())
+    #     inp = [push!(tape, Input(a)) for a in args]
+    #     out = push_call!(tape, ONNX.onnx_split, inp...; axis=1)
+    #     push_call!(tape, getfield, out, 1)
+    #     push_call!(tape, getfield, out, 2)
+    #     push_call!(tape, getfield, out, 3)
+    #     tape.result = out
+
+    #     ort_test(tape, args...)
+    # end
 end


### PR DESCRIPTION
Hello :wave: 

I tested ONNX.jl using the [openpilot supercombo model](https://github.com/commaai/openpilot/blob/master/selfdrive/modeld/models/supercombo.onnx) and found a few missing ops that I added. I can now confirm that the output of the loaded model with ONNX.jl matches that of one computed with onnxruntime for that model (I can add it as a test if needed).

This PR implements the following ops:

 - Tanh
 - Elu
 - Split
 - Concat

I was not able to implement the Split op when the split argument is not provided because the size of the output depends on the size of the input and is thus dynamic. If the OpConfig struct contained the expected output size, the outputs could still be unrolled to the tape.