### PR TITLE
Fix loading and saving graphs with multiple independent outputs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ONNX"
 uuid = "d0dd6a25-fac6-55c0-abf7-829e0c774d20"
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 EnumX = "4e289a0a-7415-4d19-859d-a7e5c4648b56"

--- a/test/saveload.jl
+++ b/test/saveload.jl
@@ -3,6 +3,17 @@ import ONNX: NodeProto, ValueInfoProto, AttributeProto, onnx_name
 
 
 @testset "Save and Load" begin
+    @testset "Multioutput" begin
+        args = rand(3, 4), rand(3, 4)
+        tape = Tape(ONNXCtx())
+        inp = [push!(tape, Input(arg)) for arg in args]
+        out1 = push_call!(tape, ONNX.add, inp...)
+        out2 = push_call!(tape, ONNX.mul, inp...)
+        res = push_call!(tape, tuple, out1, out2)
+        tape.result = res
+        ort_test(tape, args...)
+    end
+
     @testset "Basic ops" begin
         args = (rand(3, 4), rand(3, 4))
         ort_test(ONNX.add, args...)


### PR DESCRIPTION
This PR fixes #81 and adds the ability to save multioutput graphs from a tape with `tuple()` as the result variable. See the added tests for code examples.