### PR TITLE
update ONNX2JULIA_TYPE

### DIFF
--- a/src/read.jl
+++ b/src/read.jl
@@ -49,7 +49,11 @@ function array(p::TensorProto, wrap=Array)
     T = onnx2julia_types(p.data_type)
     fld = onnx2julia_data_fields(p.data_type)
     bytes = getproperty(p, fld)
-    data = !isempty(bytes) ? reinterpret(T, bytes) : reinterpret(T, p.raw_data)
+    if fld==:string_data
+        data = String.(copy(bytes))
+    else
+        data = !isempty(bytes) ? reinterpret(T, bytes) : reinterpret(T, p.raw_data)
+    end
     # note that we don't permute dimensions here, only reshape the data
     # see "Row-/Columns-major" in test/readwrite.jl for an example
     # why we don't need permutedims here

--- a/src/write.jl
+++ b/src/write.jl
@@ -108,7 +108,6 @@ for (T, field) in [(Float32, :float_data)
                    (UInt8, :raw_data)
                    (Int32, :int32_data)
                    (Int64, :int64_data)
-                   (String, :string_data)
                    (Float64, :double_data)
                    (UInt64, :uint64_data)]
     @eval TensorProto(t::AbstractArray{$T,N}, name ="") where N = TensorProto(
@@ -133,6 +132,14 @@ TensorProto(t::AbstractArray, data_type::Int32, name) = TensorProto(
     data_type=data_type,
     raw_data = reinterpret(UInt8, reshape(t, :)),
     name=name)
+
+TensorProto(t::AbstractArray{String,N}, name="") where N = TensorProto(
+    dims=collect(reverse(size(t))),
+    data_type=elem_type_code(String),
+    string_data = codeunits.(reshape(t, :)),
+    name=name)
+
+TensorProto(x::String, name ="") = TensorProto([x], name)
 
 
 function Base.show(io::IO, a::AttributeProto)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,7 +1,8 @@
 [deps]
-Umlaut = "92992a2b-8ce5-4a9c-bb9d-58be9a7dc841"
 ONNXRunTime = "e034b28e-924e-41b2-b98f-d2bbeb830c6a"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Umlaut = "92992a2b-8ce5-4a9c-bb9d-58be9a7dc841"
 
 [compat]
 Umlaut = "0.4"

--- a/test/readwrite.jl
+++ b/test/readwrite.jl
@@ -1,6 +1,7 @@
 @testset "Read and write" begin
     import ONNX
     import ONNX.ProtoBuf: encode, decode, ProtoEncoder, ProtoDecoder
+    import Random: MersenneTwister
 
     function serdeser(p::T) where T
         iob = PipeBuffer();
@@ -37,7 +38,6 @@
                                                     Int16,
                                                     Int32,
                                                     Int64,
-                                                    String,
                                                     Bool,
                                                     Float16,
                                                     Float64,
@@ -49,7 +49,14 @@
                   (1, 2, 3, 4),
                   (1, 2, 3, 4, 5))
             #exp = reshape(collect(T, 1:prod(s)), s...)
-            exp = rand(T,s)
+            exp = rand(MersenneTwister(0),T,s)
+            @test TensorProto(exp) |> serdeser |> array == exp
+        end
+    end
+
+    @testset "TensorProto(String)" begin
+        for exp in (["ONNX"],
+                    ["Julia1","Julia2","Julia3"])
             @test TensorProto(exp) |> serdeser |> array == exp
         end
     end


### PR DESCRIPTION
Hi, 
Just add all the types to ONNX2JULIA_TPYE following [onnx.proto3
](https://github.com/onnx/onnx/blob/9fad8ab3bdfd4c535b068650fdd4523022236a67/onnx/onnx.proto3#L482)

Some notes: 
1. I think that onnx.proto3 (and any other proto files) should be part of the repository for tracking the supported version. 
2. Is a Dict is the best option? The Error message that I got was cryptic (Missing Key 7). I think function would be better, but IDK. 
3. Not sure about FLOAT16 vs BFLOAT16. 
IEEE754 half-precision floating-point format (16 bits wide). (FLOAT16)
vs 
Non-IEEE floating-point format based on IEEE754 single-precision (BFLOAT16)
Do we have this type? 

### PR Checklist

- [ ] Tests are added
Not sure how to test those feature
- [ ] Documentation, if applicable
Internal stuff
