### PR TITLE
Add min max ops; filter file bug fix

### DIFF
--- a/src/load.jl
+++ b/src/load.jl
@@ -122,6 +122,14 @@ function load_node!(tape::Tape, ::OpConfig{:ONNX, :Mul}, args::VarVec, attrs::At
     return push_call!(tape, mul, args...)
 end
 
+function load_node!(tape::Tape, ::OpConfig{:ONNX, :Max}, args::VarVec, attrs::AttrDict)
+    return push_call!(tape, _max, args...)
+end
+
+function load_node!(tape::Tape, ::OpConfig{:ONNX, :Min}, args::VarVec, attrs::AttrDict)
+    return push_call!(tape, _min, args...)
+end
+
 function load_node!(tape::Tape, ::OpConfig{:ONNX, :Relu}, args::VarVec, attrs::AttrDict)
     return push_call!(tape, relu, args[1])
 end

--- a/src/ops.jl
+++ b/src/ops.jl
@@ -52,7 +52,8 @@ relu(x) = NNlib.relu.(x)
 elu(x) = NNlib.elu.(x)
 tanh(x) = Base.tanh.(x)
 maxpool(x; kernel, pad = 0, stride = 1) = NNlib.maxpool(x, kernel; pad = pad, stride = stride)
-
+_min(xs...) = min.(xs...)
+_max(xs...) = max.(xs...)
 
 # common functional implementation for batch and instance normalization based on
 # https://github.com/FluxML/Flux.jl/blob/06970a5fbbb1cb485c5d2cba597a78fb453fc713/src/layers/normalise.jl#L166-L197

--- a/src/save.jl
+++ b/src/save.jl
@@ -163,6 +163,16 @@ function save_node!(g::GraphProto, ::OpConfig{:ONNX, typeof(mul)}, op::Umlaut.Ca
     push!(g.node, nd)
 end
 
+function save_node!(g::GraphProto, ::OpConfig{:ONNX, typeof(_min)}, op::Umlaut.Call)
+    nd = NodeProto("Max", op)
+    push!(g.node, nd)
+end
+
+function save_node!(g::GraphProto, ::OpConfig{:ONNX, typeof(_max)}, op::Umlaut.Call)
+    nd = NodeProto("Min", op)
+    push!(g.node, nd)
+end
+
 
 function save_node!(g::GraphProto, ::OpConfig{:ONNX, typeof(relu)}, op::Umlaut.Call)
     nd = NodeProto("Relu", op)

--- a/src/save.jl
+++ b/src/save.jl
@@ -164,12 +164,12 @@ function save_node!(g::GraphProto, ::OpConfig{:ONNX, typeof(mul)}, op::Umlaut.Ca
 end
 
 function save_node!(g::GraphProto, ::OpConfig{:ONNX, typeof(_min)}, op::Umlaut.Call)
-    nd = NodeProto("Max", op)
+    nd = NodeProto("Min", op)
     push!(g.node, nd)
 end
 
 function save_node!(g::GraphProto, ::OpConfig{:ONNX, typeof(_max)}, op::Umlaut.Call)
-    nd = NodeProto("Min", op)
+    nd = NodeProto("Max", op)
     push!(g.node, nd)
 end
 

--- a/test/backend.jl
+++ b/test/backend.jl
@@ -39,7 +39,7 @@ const ONNX_RELEASE_URL = "https://github.com/ordicker/ONNXBackendTests.jl/releas
     """
     function outputs(dirname::String)
         readdir(dirname*"/test_data_set_0",join=true)|>
-            f->filter(contains("output"),f).|>
+            f->filter(contains(r"\/output.*\.pb"),f).|>
             pb_to_array
     end
     """
@@ -59,7 +59,7 @@ const ONNX_RELEASE_URL = "https://github.com/ordicker/ONNXBackendTests.jl/releas
     function eval_model(dirname::String)
         ## load inputs
         inputs = readdir(dirname*"/test_data_set_0",join=true)|>
-            f->filter(contains("input"),f).|>
+            f->filter(contains(r"\/input.*\.pb"),f).|>
             pb_to_array
         ## load the model
         model = load(dirname*"/model.onnx",inputs...)
@@ -70,7 +70,35 @@ const ONNX_RELEASE_URL = "https://github.com/ordicker/ONNXBackendTests.jl/releas
     @testset "Nodes" begin
         prefix = onnx_release_path * "/data/node/"
         #for dir in readdir(prefix) # TODO: pass all the tests :)
-        for dirname in ["test_add"]
+        for dirname in ["test_add",
+                        "test_min_example",
+                        #"test_min_float16",
+                        "test_min_float32",
+                        "test_min_float64",
+                        "test_min_int16",
+                        "test_min_int32",
+                        "test_min_int64",
+                        "test_min_int8",
+                        "test_min_one_input",
+                        "test_min_two_inputs",
+                        "test_min_uint16",
+                        "test_min_uint32",
+                        "test_min_uint64",
+                        "test_min_uint8",
+                        "test_max_example",
+                        #"test_max_float16",
+                        "test_max_float32",
+                        "test_max_float64",
+                        "test_max_int16",
+                        "test_max_int32",
+                        "test_max_int64",
+                        "test_max_int8",
+                        "test_max_one_input",
+                        "test_max_two_inputs",
+                        "test_max_uint16",
+                        "test_max_uint32",
+                        "test_max_uint64",
+                        "test_max_uint8"]
             onnx_output = outputs(prefix*dirname)[1] # TODO: some tests have more than 1 output
             julia_output = eval_model(prefix*dirname)
             @test onnx_output==julia_output


### PR DESCRIPTION
Hi, 

add min and max ops: 
I used [_min](https://github.com/ordicker/ONNX.jl/blob/fd5d52f0457764f2ec4e6bafbe445fff5fe20928/src/load.jl#L130) for the tape. What do you think? 
We pass all the min/max backend test (that is really impressive!), but I comment out the Float16 (I think that should be failed).
I had a small bug int the file name filter, fixed it using regex.

### PR Checklist

- [X] Tests are added
- [ ] Documentation, if applicable (internal stuff)
